### PR TITLE
Load align.el for using it's variable

### DIFF
--- a/abc-mode.el
+++ b/abc-mode.el
@@ -60,6 +60,7 @@
 (require 'easymenu)
 (require 'newcomment)
 (require 'autoinsert)
+(require 'align)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.abp\\'"  . abc-mode))


### PR DESCRIPTION
When `abc-align-bars` is executed and `align.el` is not loaded yet, then the following error happens.

```
Symbol’s value as variable is void: align-text-modes
```